### PR TITLE
No download if current version is greater than latest release.

### DIFF
--- a/src/SelfUpdateCommand.php
+++ b/src/SelfUpdateCommand.php
@@ -4,6 +4,7 @@ namespace SelfUpdate;
 
 use Composer\Semver\VersionParser;
 use Composer\Semver\Semver;
+use Composer\Semver\Comparator;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -210,7 +211,7 @@ EOT
             'compatible' => $isCompatibleOptionSet,
             'version_constraint' => $versionConstraintArg,
         ]);
-        if (null === $latestRelease || Semver::satisfies($latestRelease['version'], $this->currentVersion)) {
+        if (null === $latestRelease || Comparator::greaterThanOrEqualTo($this->currentVersion, $latestRelease['version'])) {
             $output->writeln('No update available');
             return 0;
         }


### PR DESCRIPTION
If current version is greater than latest release then self:update should not try to update.

Example:
- Current = 3.0.6-dev
- Latest = 3.0.5
- Current behavior: update (why?)
- New behavior: No available updates message.