### PR TITLE
Fix tests and --preview

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: Self update testing
-on: push
+on: [push, pull_request]
 jobs:
   # Checkout in separate job because docker image is alpine based and checkout action doesn't work.
   functional:

--- a/src/SelfUpdateCommand.php
+++ b/src/SelfUpdateCommand.php
@@ -150,7 +150,7 @@ EOT
                 continue;
             }
 
-            if (!$options['preview'] && (VersionParser::parseStability($releaseVersion) !== 'stable') || $release['prerelease']) {
+            if (!$options['preview'] && ((VersionParser::parseStability($releaseVersion) !== 'stable') || $release['prerelease'])) {
                 // If preview not requested and current version is not stable, look for the next one.
                 continue;
             }


### PR DESCRIPTION
I think #19 introduced a regression that causes prereleases to never be downloaded, even with the `--preview` flag, and obviously this broke tests too.

This fixes the bugs and also enables tests on PRs so we can catch failures before they are merged next time.