### PR TITLE
Trailing zero in version name

### DIFF
--- a/src/SelfUpdateCommand.php
+++ b/src/SelfUpdateCommand.php
@@ -32,7 +32,8 @@ class SelfUpdateCommand extends Command
     public function __construct($applicationName = null, $currentVersion = null, $gitHubRepository = null)
     {
         $this->applicationName = $applicationName;
-        $this->currentVersion = $currentVersion;
+        $version_parser = new VersionParser();
+        $this->currentVersion = $version_parser->normalize($currentVersion);
         $this->gitHubRepository = $gitHubRepository;
         $this->ignorePharRunningCheck = false;
 

--- a/src/SelfUpdateCommand.php
+++ b/src/SelfUpdateCommand.php
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem as sfFilesystem;
 
 /**
- * Update the *.phar from the latest github release.
+ * Update the *.phar from the latest GitHub release.
  *
  * @author Alexander Menk <alex.menk@gmail.com>
  */
@@ -76,7 +76,7 @@ EOT
      *
      * @throws \Exception
      *
-     * @return string[]
+     * @return array
      */
     protected function getReleasesFromGithub()
     {

--- a/src/SelfUpdateCommand.php
+++ b/src/SelfUpdateCommand.php
@@ -75,7 +75,7 @@ EOT
      *
      * @throws \Exception
      *
-     * @return array
+     * @return string[]
      */
     protected function getReleasesFromGithub()
     {
@@ -107,7 +107,7 @@ EOT
             }
 
             $parsed_releases[$normalized] = [
-                'tag_name' => $normalized,
+                'tag_name' => $release->tag_name,
                 'assets' => $release->assets,
                 'prerelease' => $release->prerelease,
             ];
@@ -138,15 +138,14 @@ EOT
               'version_constraint' => null,
             ], $options);
 
-        foreach ($this->getReleasesFromGithub() as $release) {
+        foreach ($this->getReleasesFromGithub() as $releaseVersion => $release) {
             // We do not care about this release if it does not contain assets.
             if (!isset($release['assets'][0]) || !is_object($release['assets'][0])) {
                 continue;
             }
 
-            $releaseVersion = $release['tag_name'];
             if ($options['compatible'] && !$this->satisfiesMajorVersionConstraint($releaseVersion)) {
-                // If it does not satisfies, look for the next one.
+                // If it does not satisfy, look for the next one.
                 continue;
             }
 
@@ -162,6 +161,7 @@ EOT
 
             return [
                 'version' => $releaseVersion,
+                'tag_name' => $release['tag_name'],
                 'download_url' => $release['assets'][0]->browser_download_url,
             ];
         }
@@ -219,14 +219,14 @@ EOT
 
         $fs = new sfFilesystem();
 
-        $output->writeln('Downloading ' . $this->applicationName . ' (' . $this->gitHubRepository . ') ' . $latestRelease['version']);
+        $output->writeln('Downloading ' . $this->applicationName . ' (' . $this->gitHubRepository . ') ' . $latestRelease['tag_name']);
 
         $fs->copy($latestRelease['download_url'], $tempFilename);
 
         $output->writeln('Download finished');
 
         try {
-            \error_reporting(E_ALL); // supress notices
+            \error_reporting(E_ALL); // suppress notices
 
             @chmod($tempFilename, 0777 & ~umask());
             // test the phar validity


### PR DESCRIPTION
ACLI recently switched internal version strings to include a trailing zero, i.e. 2.8.6.0, to match Composer normalized versions and keep compatibility with this package.

Multiple customers have reported confusion about this, and I think they're right, it was a mistake: https://github.com/acquia/cli/issues/1426

If nothing else, this violates semver. It's fine if Composer wants to track versions this way internally, but any part of a human interface should stick to semver.

This PR basically just prints the unnormalized, human-friendly tag name while keeping the normalized version internally.

This accounts for the trailing zero, but also preserves any number of other project-specific idiosyncrasies such as a leading `v` or release qualifiers.