### PR TITLE
Version never up to date

### DIFF
--- a/src/SelfUpdateManager.php
+++ b/src/SelfUpdateManager.php
@@ -32,7 +32,7 @@ class SelfUpdateManager
      */
     public function isUpToDate(array $options = []): bool {
         $latestRelease = $this->getLatestReleaseFromGithub($options);
-        return NULL === $latestRelease || Comparator::greaterThanOrEqualTo($this->currentVersion, $latestRelease['version']);
+        return NULL === $latestRelease || Comparator::greaterThanOrEqualTo($this->currentVersion, $latestRelease['tag_name']);
     }
 
     /**

--- a/src/SelfUpdateManager.php
+++ b/src/SelfUpdateManager.php
@@ -25,6 +25,7 @@ class SelfUpdateManager
      * which isn't available at this point in the Symfony bootstrap.
      */
     public function __construct(public string $applicationName, public string $currentVersion, public string $gitHubRepository){
+      $this->currentVersion = (new VersionParser())->normalize($this->currentVersion);
     }
 
     /**
@@ -32,7 +33,7 @@ class SelfUpdateManager
      */
     public function isUpToDate(array $options = []): bool {
         $latestRelease = $this->getLatestReleaseFromGithub($options);
-        return NULL === $latestRelease || Comparator::greaterThanOrEqualTo($this->currentVersion, $latestRelease['tag_name']);
+        return NULL === $latestRelease || Comparator::greaterThanOrEqualTo($this->currentVersion, $latestRelease['version']);
     }
 
     /**


### PR DESCRIPTION
The version always has a trailing zero; for comparison to work, the currentVersion needs to be normalized to ensure it also has a trailing zero.