### PR TITLE
CLI-1484: Ignore non-phar release assets

### DIFF
--- a/src/SelfUpdateManager.php
+++ b/src/SelfUpdateManager.php
@@ -54,8 +54,18 @@ class SelfUpdateManager
         ], $options);
 
         foreach ($this->getReleasesFromGithub() as $releaseVersion => $release) {
-            // We do not care about this release if it does not contain assets.
-            if (!isset($release['assets'][0]) || !is_object($release['assets'][0])) {
+            // Find the first asset with a .phar extension.
+            $pharAsset = null;
+            if (isset($release['assets']) && is_array($release['assets'])) {
+                foreach ($release['assets'] as $asset) {
+                    if (is_object($asset) && isset($asset->browser_download_url) && str_ends_with($asset->browser_download_url, '.phar')) {
+                        $pharAsset = $asset;
+                        break;
+                    }
+                }
+            }
+
+            if (!$pharAsset) {
                 continue;
             }
 
@@ -77,7 +87,7 @@ class SelfUpdateManager
             return [
                 'version' => $releaseVersion,
                 'tag_name' => $release['tag_name'],
-                'download_url' => $release['assets'][0]->browser_download_url,
+                'download_url' => $pharAsset->browser_download_url,
             ];
         }
 

--- a/src/SelfUpdateManager.php
+++ b/src/SelfUpdateManager.php
@@ -58,7 +58,7 @@ class SelfUpdateManager
             $pharAsset = null;
             if (isset($release['assets']) && is_array($release['assets'])) {
                 foreach ($release['assets'] as $asset) {
-                    if (is_object($asset) && isset($asset->browser_download_url) && str_ends_with($asset->browser_download_url, '.phar')) {
+                    if (is_object($asset) && isset($asset->content_type) && $asset->content_type === 'application/octet-stream') {
                         $pharAsset = $asset;
                         break;
                     }


### PR DESCRIPTION
Acquia CLI is going to start release native binaries in addition to phar assets for its releases. This is problematic because the self-updater doesn't currently consider the asset type before blindly attempting to update to it.

This PR fixes that by ensuring only assets with a `phar` file extension are downloaded.